### PR TITLE
fix: unmarshalling info and config

### DIFF
--- a/compose/testdata/docker-compose.test.yml
+++ b/compose/testdata/docker-compose.test.yml
@@ -1,4 +1,4 @@
-version: "2.1"
+version: "3.9"
 
 services:
   postgresDB:


### PR DESCRIPTION
# Description

- We are getting mixed output either Array or Multi-line JSON when doing `docker inspect or ps`.
- So trying to unmarshall to Array first. If it is successful, then return. If not, then try to parse each JSON object and unmarshal it.

## Notion Ticket

- https://linear.app/rudderstack/issue/PIPE-234/improve-error-logging-for-compose-test

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
