### PR TITLE
chore(ci): anchor release-please baseline to v0.1.3 tag

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -38,3 +38,7 @@ jobs:
           default-branch: ${{ steps.extract_branch.outputs.branch }}
           changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"chore","section":"Miscellaneous","hidden":false},{"type":"refactor","section":"Miscellaneous","hidden":false},{"type":"test","section":"Miscellaneous","hidden":false},{"type":"doc","section":"Documentation","hidden":false}]'
           bump-minor-pre-major: true
+          # Temporary: anchors the release baseline to the v0.1.3 tag so the bot
+          # computes 0.1.4 from the correct commit range. The 2023 release tags are
+          # too old for automatic detection. Remove once v0.1.4 has been released.
+          last-release-sha: f72de3bd80b7c0dde3f9f5d1dd9684ab9d9668ec # v0.1.3


### PR DESCRIPTION
# Description

Follow-up to #64. The release-please run after that merge proposed `0.1.0` instead of `0.1.4` (see #65): the bot could not associate any of the 2023 release tags with recent main history (`SHA not found in recent commits to branch main, skipping` for all four releases), and the only release marker in range — the merged-but-never-tagged release PR #24 — has no tag backing it. With no usable baseline, it fell back to treating the repo as unreleased.

This adds the `last-release-sha` input pointing at the `v0.1.3` tag commit (`f72de3b`), anchoring the baseline explicitly. On the next run the bot will update #65 in place to `chore: release 0.1.4` with a changelog covering only the commits since v0.1.3.

**Temporary override:** must be removed once v0.1.4 is released (noted in the workflow comment). After a fresh release exists at the top of main's history, natural detection self-heals and the override would otherwise re-propose 0.1.4 forever.

## Testing

- `actionlint` passes on the modified workflow

## Notion Ticket

[INT-6728](https://linear.app/rudderstack/issue/INT-6728/compose-test-fix-release-please-configuration) (Linear)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
