### PR TITLE
chore(ci): remove temporary release-please baseline anchor

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -38,7 +38,3 @@ jobs:
           default-branch: ${{ steps.extract_branch.outputs.branch }}
           changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"chore","section":"Miscellaneous","hidden":false},{"type":"refactor","section":"Miscellaneous","hidden":false},{"type":"test","section":"Miscellaneous","hidden":false},{"type":"doc","section":"Documentation","hidden":false}]'
           bump-minor-pre-major: true
-          # Temporary: anchors the release baseline to the v0.1.3 tag so the bot
-          # computes 0.1.4 from the correct commit range. The 2023 release tags are
-          # too old for automatic detection. Remove once v0.1.4 has been released.
-          last-release-sha: f72de3bd80b7c0dde3f9f5d1dd9684ab9d9668ec # v0.1.3


### PR DESCRIPTION
# Description

Removes the temporary `last-release-sha` baseline anchor added in #66, now that the release automation has completed a full cycle: release PR #65 merged and the bot created the [v0.1.5 tag and release](https://github.com/rudderlabs/compose-test/releases/tag/v0.1.5) automatically.

The anchor was needed because no release existed in the recent history window (last tag was v0.1.3 from September 2023). With v0.1.5 now at the top of main's history, natural release detection works again — and leaving the anchor in place would pin every future release computation to the v0.1.3 baseline, re-proposing already-released versions.

## Testing

- `actionlint` passes on the modified workflow

## Notion Ticket

[INT-6728](https://linear.app/rudderstack/issue/INT-6728/compose-test-fix-release-please-configuration) (Linear)

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
